### PR TITLE
placeholdertest: fix bug in camera capture

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,9 +14,7 @@
   <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
 
   <link rel="manifest" href="/sparcl.webmanifest">
-  
-  <script>var parcelRequire;</script>
-    
+
   <title>spARcl</title>
 
   <style>
@@ -47,9 +45,7 @@
   </style>
 
   <!-- Workaround for a peerjs problem that 'parcelRequire' is not defined. More info here: https://github.com/peers/peerjs/issues/753 -->
-  <script>
-    var parcelRequire;
-  </script>
+  <script>let parcelRequire;</script>
 </head>
 <body>
 <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/snowpack.config.js
+++ b/snowpack.config.js
@@ -26,7 +26,7 @@ module.exports = {
     // source: "remote"
   },
   devOptions: {
-    secure: false,
+    secure: true,
     hostname: '0.0.0.0',
     open: 'none'
   },

--- a/src/core/cameraCapture.js
+++ b/src/core/cameraCapture.js
@@ -5,6 +5,8 @@
 // TODO: Leftover code from camera access sample from Chromium site. Needs to be better adapted to our requirements.
 // See more details here: https://source.chromium.org/chromium/chromium/src/+/master:third_party/webxr_test_pages/webxr-samples/proposals/camera-access-barebones.html;bpv=0
 
+import { checkGLError } from '@core/devTools';
+
 let shaderProgram = null;
 let vertexBuffer = null;
 let aCoordLoc = null;
@@ -127,10 +129,7 @@ export function getCameraIntrinsics(projectionMatrix, viewport) {
 }
 
 export function initCameraCaptureScene(gl) {
-    let e = gl.getError()
-    if (e != 0) {
-        console.warn("GL error at initCameraCaptureScene() beginning: ", e);
-    }
+    checkGLError(gl, "initCameraCaptureScene() begin")
 
     var vertices = [
         -1.0, 1.0, 0.0
@@ -171,22 +170,20 @@ export function initCameraCaptureScene(gl) {
     aCoordLoc = gl.getAttribLocation(shaderProgram, "coordinates");
     uSamplerLoc = gl.getUniformLocation(shaderProgram, "uSampler");
 
-    e = gl.getError()
-    if (e != 0) {
-        console.warn("GL error at initCameraCaptureScene() end: ", e);
-    }
+    checkGLError(gl, "initCameraCaptureScene() end");
 }
 
 
 export function drawCameraCaptureScene(gl, cameraTexture) {
-    let e = gl.getError()
-    if (e != 0) {
-        console.warn("GL error at drawCameraCaptureScene() beginning: ", e);
-    }
+    checkGLError(gl, "drawCameraCaptureScene() begin");
 
     // Save ID of the previous shader
     const prevShaderId = gl.getParameter(gl.CURRENT_PROGRAM);
+    const prevActiveTexture = gl.getParameter(gl.ACTIVE_TEXTURE);
+    const prevTextureId = gl.getParameter(gl.TEXTURE_BINDING_2D)
+    const prevArrayBuffer = gl.getParameter(gl.ARRAY_BUFFER_BINDING);
 
+    // Bind the shader program
     gl.useProgram(shaderProgram);
 
     // Bind the geometry
@@ -202,13 +199,14 @@ export function drawCameraCaptureScene(gl, cameraTexture) {
     // Draw the single point
     gl.drawArrays(gl.POINTS, 0, 1);
 
-    // Restore the previous shader
+    // cleanup
+    gl.activeTexture(prevActiveTexture);
+    gl.bindTexture(gl.TEXTURE_2D, prevTextureId);
+    gl.disableVertexAttribArray(aCoordLoc);
+    gl.bindBuffer(gl.ARRAY_BUFFER, prevArrayBuffer);
     gl.useProgram(prevShaderId);
 
-    e = gl.getError()
-    if (e != 0) {
-        console.warn("GL error at drawCameraCaptureScene() end: ", e);
-    }
+    checkGLError(gl, "drawCameraCaptureScene() end");
 }
 
 let readback_pixels = null; // buffer that stores the last image read from the GPU
@@ -226,10 +224,7 @@ let readback_pixels = null; // buffer that stores the last image read from the G
  * @returns {string}     base64 encoded string of the image (will likely change)
  */
  export function createImageFromTexture(gl, texture, imageWidth, imageHeight) {
-    let e = gl.getError()
-    if (e != 0) {
-        console.warn("GL error at createImageFromTexture() beginning: ", e);
-    }
+    checkGLError(gl, "createImageFromTexture() begin");
 
     const prev_framebuffer = gl.getParameter(gl.FRAMEBUFFER_BINDING); // save the screen framebuffer ID
 
@@ -297,10 +292,7 @@ let readback_pixels = null; // buffer that stores the last image read from the G
     context.putImageData(imageFlip, 0, 0);
     let imageBase64 = canvas.toDataURL('image/jpeg');
 
-    e = gl.getError()
-    if (e != 0) {
-        console.warn("GL error at createImageFromTexture() end: ", e);
-    }
+    checkGLError(gl, "createImageFromTexture() end");
 
     return imageBase64;
 }

--- a/src/core/devTools.js
+++ b/src/core/devTools.js
@@ -9,6 +9,26 @@ import { Quat, Euler, Vec3, Mat4, Transform } from 'ogl';
 // Here a good overview on geodetic distance calculations:
 // https://www.movable-type.co.uk/scripts/latlong.html
 
+
+/**
+ * Checks for pending OpenGL errors
+ * @param {glBinding} gl OpenGL binding
+ * @param {string} message 
+ * @returns {boolean} false if no error, true if there was an error 
+ */
+export function checkGLError(gl, message) {
+    if (gl == null) {
+        console.warn("checkGLError called but there is no GL context")
+        return true;
+    }
+    let e = gl.getError()
+    if (e != 0) {
+        console.warn("GL error - " + message + ": ", e);
+        return true;
+    }
+    return false;
+}
+
 /**
  * Pretty logging of a gl-matrix quaternion
 * @param name The name to print

--- a/src/core/engines/ogl/ogl.js
+++ b/src/core/engines/ogl/ogl.js
@@ -12,7 +12,7 @@ import {getAxes, getDefaultPlaceholder, getExperiencePlaceholder, getDefaultMark
 import { convertGeo2WebVec3, convertWeb2GeoVec3, convertWeb2GeoQuat, convertAugmentedCityCam2WebQuat, convertAugmentedCityCam2WebVec3,
          getRelativeGlobalPosition, getRelativeOrientation, geodetic_to_enu, toDegrees, getEarthRadiusAt } from '@core/locationTools';
 
-import { printQuat, printGlmQuat, printOglTransform } from '@core/devTools';
+import { printQuat, printGlmQuat, printOglTransform, checkGLError } from '@core/devTools';
 
 import { quat, vec3 } from 'gl-matrix';
 
@@ -54,6 +54,8 @@ export default class ogl {
         this.resize();
 
         document.addEventListener('click', this._handleEvent);
+
+        checkGLError(gl, "OGL init end");
     }
 
     /**
@@ -398,6 +400,8 @@ export default class ogl {
      * @param view  XRView      Provided by WebXR
      */
     render(time, view) {
+        checkGLError(gl, "OGL render() begin");
+
         const position = view.transform.position;
         const orientation = view.transform.orientation;
 
@@ -412,6 +416,8 @@ export default class ogl {
         uniforms.time.forEach(model => model.program.uniforms.uTime.value = time * 0.001);  // Time in seconds
 
         renderer.render({scene, camera});
+
+        checkGLError(gl, "OGL render() end");
     }
 
     /**

--- a/src/core/engines/ogl/shaders/defaultfragment.glsl
+++ b/src/core/engines/ogl/shaders/defaultfragment.glsl
@@ -8,6 +8,7 @@ precision highp float;
 varying vec3 vNormal;
 
 uniform vec4 uColor;
+uniform float uTime;
 
 void main() {
     vec3 normal = normalize(vNormal);

--- a/src/core/engines/ogl/shaders/defaultvertex.glsl
+++ b/src/core/engines/ogl/shaders/defaultvertex.glsl
@@ -5,18 +5,18 @@
 
 attribute vec3 position;
 attribute vec3 normal;
-attribute vec2 uv;
+//attribute vec2 uv;
 
 uniform mat4 modelViewMatrix;
 uniform mat4 projectionMatrix;
 uniform mat3 normalMatrix;
 
 varying vec3 vNormal;
-varying vec2 vUv;
+//varying vec2 vUv;
 
 void main() {
     vNormal = normalize(normalMatrix * normal);
-    vUv = uv;
+    //vUv = uv;
 
     gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
 }

--- a/src/core/engines/webxr.js
+++ b/src/core/engines/webxr.js
@@ -4,7 +4,7 @@
 */
 
 import { initCameraCaptureScene, drawCameraCaptureScene, createImageFromTexture, getCameraIntrinsics } from '@core/cameraCapture';
-
+import { checkGLError } from '@core/devTools'
 
 let endedCallback, devFrameCallback, creativeFrameCallback, oscpFrameCallback, markerFrameCallback,
     experimentFrameCallback, noExperimentResultCallback, onFrameUpdate;
@@ -20,6 +20,7 @@ let maximumFrameTime = 1000/30; // 30 FPS
  * WebXR implementation of the AR engine.
  */
 export default class webxr {
+
     /**
      * Start specific session for experiment mode.
      *
@@ -171,6 +172,8 @@ export default class webxr {
         const cameraTexture = this.glBinding.getCameraImage(frame, view);
         drawCameraCaptureScene(gl, cameraTexture);
 
+        checkGLError(gl, "getCameraTexture() end");
+
         return cameraTexture;
     }
     // NOTE: since Chrome update in June 2021, the getCameraImage(frame, view) method is not available anymore
@@ -187,7 +190,6 @@ export default class webxr {
      * @returns {WebGLTexture}
      */
     getCameraTexture2(view) {
-
         // For an application working in camera texture space, get the camera
         // intrinsics based on the camera texture width/height which may be
         // different from the XR framebuffer width/height.
@@ -210,6 +212,8 @@ export default class webxr {
         // NOTE: if we do not draw anything on pose update for more than 5 frames, Chrome's WebXR sends warnings
         // See OnFrameEnd() in https://chromium.googlesource.com/chromium/src/third_party/+/master/blink/renderer/modules/xr/xr_webgl_layer.cc
         drawCameraCaptureScene(gl, cameraTexture);
+
+        checkGLError(gl, "getCameraTexture2() end");
 
         return cameraTexture;
     }
@@ -332,6 +336,8 @@ export default class webxr {
      * @param frame  XRFrame        The frame to handle
      */
     _onFrameUpdate(time, frame) {
+        checkGLError(gl, "_onFrameUpdate() 1");
+
         const session = frame.session;
         session.requestAnimationFrame(onFrameUpdate);
 
@@ -367,9 +373,13 @@ export default class webxr {
                 creativeFrameCallback(time, frame, floorPose);
             }
 
+            checkGLError(gl, "_onFrameUpdate() 2");
+
             if (oscpFrameCallback) {
                 oscpFrameCallback(time, frame, floorPose);
             }
+
+            checkGLError(gl, "_onFrameUpdate() 3");
 
             if (markerFrameCallback) {
                 const results = frame.getImageTrackingResults();
@@ -379,5 +389,7 @@ export default class webxr {
                 }
             }
         }
+
+        checkGLError(gl, "_onFrameUpdate() 4");
     }
 }


### PR DESCRIPTION
fixed WebGL errors in OGL rendering call, caused by not properly cleaning up the GL state after capturing the camera texture