### PR TITLE
Replace package buhrmi with thumb-ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "automerge": "^0.14.2",
-        "buhrmi": "^0.0.15",
         "chai": "^4.2.0",
         "geodesy": "^2.2.1",
         "gl-matrix": "^3.3.0",
@@ -24,6 +23,7 @@
         "scd-access": "^0.1.0",
         "ssd-access": "^0.2.0",
         "svelte": "^3.38.2",
+        "thumb-ui": "^0.0.16",
         "uuid": "^8.3.2"
       },
       "devDependencies": {
@@ -1627,11 +1627,6 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
-    "node_modules/buhrmi": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/buhrmi/-/buhrmi-0.0.15.tgz",
-      "integrity": "sha512-1hbtzzWFNN9xTHJhUZS1fvyQIUTC/Qdv0UM/5p0V5pk/ByGpAPwevS9Tg8ImeiNnMdHQtzHofbM0hUcXVgnEeg=="
-    },
     "node_modules/builtin-modules": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
@@ -1759,6 +1754,7 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -2453,7 +2449,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -2550,6 +2547,7 @@
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
       "dependencies": {
+        "@types/yauzl": "^2.9.1",
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
@@ -5304,6 +5302,9 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.50.2.tgz",
       "integrity": "sha512-Ra5JkxSiZPZZFnvE68KWtlrLnZGg5LNaV1n1esq4ch69P7ReeoRVlrTuL/k+L/GJfcowA5An0BEhEq2Hfzwl6w==",
       "dev": true,
+      "dependencies": {
+        "fsevents": "~2.3.1"
+      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -5520,6 +5521,7 @@
         "default-browser-id": "^2.0.0",
         "esbuild": "^0.9.3",
         "fdir": "^5.0.0",
+        "fsevents": "^2.2.0",
         "open": "^7.0.4",
         "picomatch": "^2.2.2",
         "resolve": "^1.20.0",
@@ -5918,6 +5920,11 @@
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
       }
+    },
+    "node_modules/thumb-ui": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/thumb-ui/-/thumb-ui-0.0.16.tgz",
+      "integrity": "sha512-SAIE0ahq1pXGxozM7EuZP+szCPtgbav7M9oJVmSOjixviAmtKJB4EaatEXXDfKjXZbjYr567Lxc6c2HfoMKJ1w=="
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
@@ -7752,11 +7759,6 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
-    },
-    "buhrmi": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/buhrmi/-/buhrmi-0.0.15.tgz",
-      "integrity": "sha512-1hbtzzWFNN9xTHJhUZS1fvyQIUTC/Qdv0UM/5p0V5pk/ByGpAPwevS9Tg8ImeiNnMdHQtzHofbM0hUcXVgnEeg=="
     },
     "builtin-modules": {
       "version": "3.2.0",
@@ -11030,6 +11032,11 @@
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
       }
+    },
+    "thumb-ui": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/thumb-ui/-/thumb-ui-0.0.16.tgz",
+      "integrity": "sha512-SAIE0ahq1pXGxozM7EuZP+szCPtgbav7M9oJVmSOjixviAmtKJB4EaatEXXDfKjXZbjYr567Lxc6c2HfoMKJ1w=="
     },
     "to-fast-properties": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   },
   "dependencies": {
     "automerge": "^0.14.2",
-    "buhrmi": "^0.0.15",
     "chai": "^4.2.0",
     "geodesy": "^2.2.1",
     "gl-matrix": "^3.3.0",
@@ -49,6 +48,7 @@
     "scd-access": "^0.1.0",
     "ssd-access": "^0.2.0",
     "svelte": "^3.38.2",
+    "thumb-ui": "^0.0.16",
     "uuid": "^8.3.2"
   }
 }

--- a/src/components/dom-overlays/WelcomeOverlay.svelte
+++ b/src/components/dom-overlays/WelcomeOverlay.svelte
@@ -10,7 +10,7 @@
 <script>
     import { createEventDispatcher } from 'svelte';
 
-    import { Swipeable, Screen, Controls } from 'buhrmi';
+    import { Swipeable, Screen, Controls } from 'thumb-ui';
 
     import { hasIntroSeen, arIsAvailable, isLocationAccessAllowed, arMode } from '@src/stateStore';
     import { infoGreeting, info, introGreeting, intro, arOkMessage, dashboardOkLabel,


### PR DESCRIPTION
The maintainer of the package has renamed it,
so npm install in a fresh environment fails.
Fixed by replacing dependency and import with new name.
Not sure if the changed version (0.0.15 -> 0.0.16) has any impact