### PR TITLE
hotfix for AC content type change

### DIFF
--- a/src/components/Viewer.svelte
+++ b/src/components/Viewer.svelte
@@ -410,8 +410,9 @@
 
                 // Difficult to generalize, because there are no types defined yet.
                 switch (record.content.type) {
-                // TODO: placeholder is a temporary type we use in all demos until we come up with a good list
-                case "placeholder":
+                case "MODEL_3D":
+                case "3D": // NOTE: AC-specific type 3D is the same as OSCP MODEL_3D // AC added it in Nov.2022
+                case "placeholder": // NOTE: placeholder is a temporary type we use in all demos until we come up with a good list // AC removed it in Nov.2022
                     showContentsLog = true; // show log if at least one 3D object was received
 
                     let globalObjectPose = record.content.geopose;
@@ -419,7 +420,8 @@
                     let position = localObjectPose.position;
                     let orientation = localObjectPose.quaternion;
 
-                    // Augmented City proprietary structure
+                    // Augmented City proprietary structure (has no refs, has type infosticker and has custom_data fieds)
+                    // kept for backward compatibility and will be removed
                     //if (record.content.custom_data?.sticker_type.toLowerCase() === 'other') { // sticker_type was removed in Nov.2021
                     if (record.content.custom_data?.sticker_subtype != undefined) {
                         const subtype = record.content.custom_data.sticker_subtype.toLowerCase();
@@ -440,21 +442,26 @@
                                 break;
                         }
                     } else if (record.content.refs != undefined && record.content.refs.length > 0) {
-                        // Orbit custom data type
+                        // OSCP-compliant 3D content structure 
                         // TODO load all, not only first reference
                         const contentType = record.content.refs[0].contentType;
                         const url = record.content.refs[0].url;
                         if (contentType.includes("gltf")) {
                             tdEngine.addModel(position, orientation, url);
                         } else {
+                            // we cannot load anything else but GLTF
+                            // so draw a placeholder instead
                             const placeholder = tdEngine.addPlaceholder(record.content.keywords, position, orientation);
                             handlePlaceholderDefinitions(tdEngine, placeholder, /* record.content.definition */);
                         }
                     } else {
+                        // we cannot load anything else but OSCP-compliant and AC-compliant 3D models
+                        // so draw a placeholder instead
                         const placeholder = tdEngine.addPlaceholder(record.content.keywords, position, orientation);
                         handlePlaceholderDefinitions(tdEngine, placeholder, /* record.content.definition */);
                     }
                     break;
+
                 case "ephemeral":
                     // ISMAR2021 demo
                     if (record.tenant === 'ISMAR2021demo') {
@@ -465,6 +472,7 @@
                         tdEngine.addObject(localObjectPose.position, localObjectPose.quaternion, object_description);
                     }
                     break;
+
                 default:
                     console.log(record.content.title + " has unexpected content type: " + record.content.type);
                     console.log(record.content);

--- a/src/components/viewer-implementations/Viewer-Experiment.svelte
+++ b/src/components/viewer-implementations/Viewer-Experiment.svelte
@@ -839,14 +839,17 @@
                 //tdEngine.addSpatialContentRecord(globalObjectPose, record.content)
 
                 // Difficult to generalize, because there are no types defined yet.
-                if (record.content.type === 'placeholder') {
-
+                switch (record.content.type) {
+                case "MODEL_3D":
+                case "3D": // NOTE: AC-specific type 3D is the same as OSCP MODEL_3D // AC added it in Nov.2022
+                case "placeholder": // NOTE: placeholder is a temporary type we use in all demos until we come up with a good list // AC removed it in Nov.2022            
                     let globalObjectPose = record.content.geopose;
                     let localObjectPose = tdEngine.convertGeoPoseToLocalPose(globalObjectPose);
                     let position = localObjectPose.position;
                     let orientation = localObjectPose.quaternion;
 
-                    // Augmented City proprietary structure
+                    // Augmented City proprietary structure (has no refs, has type infosticker and has custom_data fieds)
+                    // kept for backward compatibility and will be removed
                     //if (record.content.custom_data?.sticker_type.toLowerCase() === 'other') { // sticker_type was removed in Nov.2021
                     if (record.content.custom_data?.sticker_subtype != undefined) {
                         const subtype = record.content.custom_data.sticker_subtype.toLowerCase();
@@ -867,30 +870,42 @@
                                 break;
                         }
                     } else if (record.content.refs != undefined && record.content.refs.length > 0) {
-                        // Orbit custom data type
+                        // OSCP-compliant 3D content structure      
+                        // TODO load all, not only first reference
                         const contentType = record.content.refs[0].contentType;
                         const url = record.content.refs[0].url;
                         if (contentType.includes("gltf")) {
                             tdEngine.addModel(position, orientation, url);
                         } else {
+                            // we cannot load anything else but GLTF
+                            // so draw a placeholder instead
                             const placeholder = tdEngine.addPlaceholder(record.content.keywords, position, orientation);
                             handlePlaceholderDefinitions(tdEngine, placeholder, /* record.content.definition */);
                         }
                     } else {
+                        // we cannot load anything else but OSCP-compliant and AC-compliant 3D models
+                        // so draw a placeholder instead
                         const placeholder = tdEngine.addPlaceholder(record.content.keywords, position, orientation);
                         handlePlaceholderDefinitions(tdEngine, placeholder, /* record.content.definition */);
                     }
-                }
+                    break;
+                
+                case 'ephemeral':
+                    // ISMAR2021 demo
+                    if (record.tenant === 'ISMAR2021demo') {
+                        console.log("ISMAR2021demo object received!")
+                        let object_description = record.content.object_description;
+                        let globalObjectPose = record.content.geopose;
+                        let localObjectPose = tdEngine.convertGeoPoseToLocalPose(globalObjectPose);
+                        tdEngine.addObject(localObjectPose.position, localObjectPose.quaternion, object_description);
+                    }
+                    break;  
 
-                if (record.tenant === 'ISMAR2021demo') {
-                    console.log("ISMAR2021demo object received!")
-                    let object_description = record.content.object_description;
-                    let globalObjectPose = record.content.geopose;
-                    let localObjectPose = tdEngine.convertGeoPoseToLocalPose(globalObjectPose);
-                    printOglTransform("localObjectPose", localObjectPose);
-                    tdEngine.addObject(localObjectPose.position, localObjectPose.quaternion, object_description);
+                default:
+                    console.log(record.content.title + " has unexpected content type: " + record.content.type);
+                    console.log(record.content);
+                    break;
                 }
-
                 //wait(1000).then(() => receivedContentTitles = []); // clear the list after a timer
 
                 // TODO: Anchor placeholder for better visual stability?!

--- a/src/components/viewer-implementations/Viewer-Marker.svelte
+++ b/src/components/viewer-implementations/Viewer-Marker.svelte
@@ -675,14 +675,17 @@
                 //tdEngine.addSpatialContentRecord(globalObjectPose, record.content)
 
                 // Difficult to generalize, because there are no types defined yet.
-                if (record.content.type === 'placeholder') {
-
+                switch (record.content.type) {
+                case 'MODEL_3D':
+                case '3D': // TODO: should be removed // AC added it in Nov.2022
+                case 'placeholder': // TODO: should be removed // AC removed it in Nov.2022
                     let globalObjectPose = record.content.geopose;
                     let localObjectPose = tdEngine.convertGeoPoseToLocalPose(globalObjectPose);
                     let position = localObjectPose.position;
                     let orientation = localObjectPose.quaternion;
 
-                    // Augmented City proprietary structure
+                    // Augmented City proprietary structure (has no refs, has type infosticker and has custom_data fieds)
+                    // kept for backward compatibility and will be removed
                     //if (record.content.custom_data?.sticker_type.toLowerCase() === 'other') { // sticker_type was removed in Nov.2021
                     if (record.content.custom_data?.sticker_subtype != undefined) {
                         const subtype = record.content.custom_data.sticker_subtype.toLowerCase();
@@ -703,9 +706,17 @@
                                 break;
                         }
                     } else {
+                        // we cannot load anything else but AC-compliant 3D models
+                        // so draw a placeholder instead
                         const placeholder = tdEngine.addPlaceholder(record.content.keywords, position, orientation);
                         handlePlaceholderDefinitions(tdEngine, placeholder, /* record.content.definition */);
                     }
+                    break;
+
+                default:
+                    console.log(record.content.title + " has unexpected content type: " + record.content.type);
+                    console.log(record.content);
+                    break;
                 }
 
                 //wait(1000).then(() => receivedContentTitles = []); // clear the list after a timer


### PR DESCRIPTION
we used to have 'placeholder' as content.type for all objects in our demos. AC upgraded their API to return '3D' for all 3D objects and now they correctly fill the content.refs so we can use those URLs and do not need to fiddle with sticker custom_data anymore

this fix is backward compatible, the old 'placeholder' entries are still accepted